### PR TITLE
workaround Meizu legacy camera blob crash

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -62,6 +62,13 @@ ifeq ($(strip $(TARGET_ARCH)),mips)
   endif
 endif
 
+# workaround Meizu camera blob passing wrong struct sizes
+ifeq ($(BOARD_HAS_MTK_HARDWARE),true)
+ifeq ($(BOARD_USES_LEGACY_MTK_AV_BLOB),true)
+LOCAL_CFLAGS += -DUSE_LEGACY_MTK_AV_BLOB
+endif
+endif
+
 LOCAL_MODULE := libjpeg_static
 
 include $(BUILD_STATIC_LIBRARY)

--- a/jcapimin.c
+++ b/jcapimin.c
@@ -35,9 +35,11 @@ jpeg_CreateCompress (j_compress_ptr cinfo, int version, size_t structsize)
   cinfo->mem = NULL;		/* so jpeg_destroy knows mem mgr not called */
   if (version != JPEG_LIB_VERSION)
     ERREXIT2(cinfo, JERR_BAD_LIB_VERSION, JPEG_LIB_VERSION, version);
+#ifndef USE_LEGACY_MTK_AV_BLOB
   if (structsize != SIZEOF(struct jpeg_compress_struct))
     ERREXIT2(cinfo, JERR_BAD_STRUCT_SIZE, 
 	     (int) SIZEOF(struct jpeg_compress_struct), (int) structsize);
+#endif
 
   /* For debugging purposes, we zero the whole master structure.
    * But the application has already set the err pointer, and may have set


### PR DESCRIPTION
Change-Id: I4732fa2c7652309c83487f66b5e390ec9f32af9a